### PR TITLE
small modification to strlcpy.c so the flags discovered

### DIFF
--- a/strlcpy.c
+++ b/strlcpy.c
@@ -27,6 +27,8 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "config.h"
+
 #ifndef HAVE_STRLCPY
 
 #include <sys/types.h>


### PR DESCRIPTION
small modification to strlcpy.c so the flags discovered by ./configure are actually used during compilation
