### PR TITLE
Add support to output in BIRD prefix-list style

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ The options are as follows:
 	> try to aggregate generated filters as much as possible (not all
     output formats supported).
 
+-    -b
+
+	> generate output in BIRD format (default: Cisco).
+
 -    -d      
 
 	> enable some debugging output.

--- a/bgpq3.8
+++ b/bgpq3.8
@@ -60,6 +60,8 @@ generate IPv6 prefix/access-lists (IPv4 by default).
 .It Fl A
 try to aggregate prefix-lists as much as possible (not all output
 formats supported).
+.It Fl b
+generate output in BIRD format (default: Cisco).
 .It Fl d
 enable some debugging output.
 .It Fl D

--- a/bgpq3.h
+++ b/bgpq3.h
@@ -8,7 +8,8 @@ typedef enum {
 	V_CISCO = 0,
 	V_JUNIPER,
 	V_CISCO_XR,
-	V_JSON
+	V_JSON,
+	V_BIRD
 } bgpq_vendor_t;
 
 typedef enum { 

--- a/bgpq3_printer.c
+++ b/bgpq3_printer.c
@@ -271,6 +271,32 @@ checkSon:
 };
 
 void
+bgpq3_print_bird_prefix(struct sx_radix_node* n, void* ff)
+{
+	char prefix[128];
+	FILE* f=(FILE*)ff;
+	if(n->isGlue)
+		goto checkSon;
+	if(!f)
+		f=stdout;
+	sx_prefix_snprintf(&n->prefix, prefix, sizeof(prefix));
+	if (!n->isAggregate) {
+		fprintf(f, "%s\n    %s",
+			needscomma?",":"", prefix);
+	} else if (n->aggregateLow > n->prefix.masklen) {
+		fprintf(f, "%s\n    %s{%u,%u}",
+			needscomma?",":"", prefix, n->aggregateLow, n->aggregateHi);
+	} else {
+		fprintf(f, "%s\n    %s{%u,%u}",
+			needscomma?",":"", prefix, n->prefix.masklen, n->aggregateHi);
+	};
+	needscomma=1;
+checkSon:
+	if(n->son)
+		bgpq3_print_bird_prefix(n->son, ff);
+};
+
+void
 bgpq3_print_jrfilter(struct sx_radix_node* n, void* ff)
 { 
 	char prefix[128];
@@ -480,6 +506,16 @@ bgpq3_print_json_prefixlist(FILE* f, struct bgpq_expander* b)
 };
 
 int
+bgpq3_print_bird_prefixlist(FILE* f, struct bgpq_expander* b)
+{
+	fprintf(f,"%s = [",
+		b->name?b->name:"NN");
+	sx_radix_tree_foreach(b->tree,bgpq3_print_bird_prefix,f);
+	fprintf(f,"\n];\n");
+	return 0;
+};
+
+int
 bgpq3_print_cisco_eacl(FILE* f, struct bgpq_expander* b)
 { 
 	bname=b->name;
@@ -497,6 +533,7 @@ bgpq3_print_prefixlist(FILE* f, struct bgpq_expander* b)
 		case V_CISCO: return bgpq3_print_cisco_prefixlist(f,b);
 		case V_CISCO_XR: return bgpq3_print_ciscoxr_prefixlist(f,b);
 		case V_JSON: return bgpq3_print_json_prefixlist(f,b);
+		case V_BIRD: return bgpq3_print_bird_prefixlist(f,b);
 	};
 	return 0;
 };
@@ -509,6 +546,7 @@ bgpq3_print_eacl(FILE* f, struct bgpq_expander* b)
 		case V_CISCO: return bgpq3_print_cisco_eacl(f,b);
 		case V_CISCO_XR: sx_report(SX_FATAL, "unreachable point\n");
 		case V_JSON: sx_report(SX_FATAL, "unreachable point\n");
+		case V_BIRD: sx_report(SX_FATAL, "unreachable point\n");
 	};
 	return 0;
 };


### PR DESCRIPTION
The -b option is useful for Route Server operators which want to generate BIRD configurations without going through the JSON step, also works with -6 & -A 
