### PR TITLE
Avoid producing empty Juniper route-filter sets

### DIFF
--- a/bgpq3_printer.c
+++ b/bgpq3_printer.c
@@ -465,7 +465,12 @@ bgpq3_print_juniper_routefilter(FILE* f, struct bgpq_expander* b)
 		if(b->match) 
 			fprintf(f,"    %s;\n",b->match);
 	};
-	sx_radix_tree_foreach(b->tree,bgpq3_print_jrfilter,f);
+	if(b->tree->head) {
+		sx_radix_tree_foreach(b->tree,bgpq3_print_jrfilter,f);
+	} else {
+		fprintf(f, "%s   route-filter %s/0 orlonger reject;\n",
+			c?" ":"", b->family==AF_INET?"0.0.0.0":"::");
+	};
 	if(c) { 
 		fprintf(f, "   }\n  }\n }\n}\n");
 	} else { 


### PR DESCRIPTION
An empty 'from {}' stanza will be removed by JUNOS, which causes the
resulting policy-filter to accept all routes, which is hardly the
expected or desired result. This patch fixes that by replacing an empty
set of routes with a single route-filter entry that will reject all
routes for the given address family.
