### PR TITLE
Add support for "%N" option in user-defined format.

### DIFF
--- a/bgpq3_printer.c
+++ b/bgpq3_printer.c
@@ -646,7 +646,7 @@ bgpq3_print_format_prefix(struct sx_radix_node* n, void* ff)
 	if(!f)
 		f=stdout;
 	memset(prefix, 0, sizeof(prefix));
-	sx_prefix_snprintf_fmt(&n->prefix, prefix, sizeof(prefix), b->format);
+	sx_prefix_snprintf_fmt(&n->prefix, prefix, sizeof(prefix), b->name?b->name:"NN", b->format);
 	fprintf(f, "%s", prefix);
 };
 

--- a/sx_prefix.c
+++ b/sx_prefix.c
@@ -266,7 +266,7 @@ sx_prefix_snprintf(struct sx_prefix* p, char* rbuffer, int srb)
 
 int
 sx_prefix_snprintf_fmt(struct sx_prefix* p, char* buffer, int size,
-	const char* format)
+	char *b, const char* format)
 {
 	unsigned off=0;
 	const char* c=format;
@@ -283,6 +283,9 @@ sx_prefix_snprintf_fmt(struct sx_prefix* p, char* buffer, int size,
 					break;
 				case '%':
 					buffer[off++]='%';
+					break;
+				case 'N':
+					off+=snprintf(buffer+off,size-off,"%s",b);
 					break;
 				default :
 					sx_report(SX_ERROR, "Unknown format char '%c'\n", *(c+1));

--- a/sx_prefix.h
+++ b/sx_prefix.h
@@ -50,7 +50,7 @@ int sx_prefix_range_parse(struct sx_radix_tree* t, int af, int ml, char* text);
 int sx_prefix_fprint(FILE* f, struct sx_prefix* p);
 int sx_prefix_snprintf(struct sx_prefix* p, char* rbuffer, int srb);
 int sx_prefix_snprintf_fmt(struct sx_prefix* p, char* rbuffer, int srb,
-	const char* fmt);
+	char *b, const char* fmt);
 int sx_prefix_jsnprintf(struct sx_prefix* p, char* rbuffer, int srb);
 struct sx_radix_tree* sx_radix_tree_new(int af);
 struct sx_radix_node* sx_radix_node_new(struct sx_prefix* prefix);


### PR DESCRIPTION
"%N" allows to put a name in the user-defined output.
I'm using OpenBGPd and I use macros to easily identify peers. This patch allows to generate filters using the macro
`$ ./bgpq3 -6 -F "allow from %N_v6 prefix %n/%l\n" -l \$AuvergneWireless  AS-AUVWIRELESS` outputs `allow from $AuvergneWireless_v6 prefix 2a00:6060:8000::/48`