### PR TITLE
Return 1 in case of error and fix OpenBSD compilation

### DIFF
--- a/bgpq3.c
+++ b/bgpq3.c
@@ -568,13 +568,13 @@ main(int argc, char* argv[])
 		default    :
 		case T_NONE: sx_report(SX_FATAL,"Unreachable point... call snar\n");
 			exit(1);
-		case T_ASPATH: bgpq3_print_aspath(stdout,&expander);
+		case T_ASPATH: return bgpq3_print_aspath(stdout,&expander);
 			break;
-		case T_OASPATH: bgpq3_print_oaspath(stdout,&expander);
+		case T_OASPATH: return bgpq3_print_oaspath(stdout,&expander);
 			break;
-		case T_PREFIXLIST: bgpq3_print_prefixlist(stdout,&expander);
+		case T_PREFIXLIST: return bgpq3_print_prefixlist(stdout,&expander);
 			break;
-		case T_EACL: bgpq3_print_eacl(stdout,&expander);
+		case T_EACL: return bgpq3_print_eacl(stdout,&expander);
 			break;
 	};
 

--- a/bgpq3_printer.c
+++ b/bgpq3_printer.c
@@ -427,6 +427,7 @@ bgpq3_print_aspath(FILE* f, struct bgpq_expander* b)
 		return bgpq3_print_nokia_aspath(f,b);
 	} else {
 		sx_report(SX_FATAL,"Unknown vendor %i\n", b->vendor);
+		return 1;
 	};
 	return 0;
 };
@@ -446,6 +447,7 @@ bgpq3_print_oaspath(FILE* f, struct bgpq_expander* b)
 		return bgpq3_print_nokia_oaspath(f,b);
 	} else {
 		sx_report(SX_FATAL,"Unknown vendor %i\n", b->vendor);
+		return 1;
 	};
 	return 0;
 };
@@ -879,6 +881,7 @@ bgpq3_print_openbgpd_prefixlist(FILE* f, struct bgpq_expander* b)
 	} else {
 		fprintf(f, "# generated prefix-list %s (AS %u) is empty\n", bname, b->asnumber);
 		fprintf(f, "deny from AS %u\n", b->asnumber);
+		return 1;
 	};
 	return 0;
 };
@@ -897,6 +900,7 @@ bgpq3_print_cisco_prefixlist(FILE* f, struct bgpq_expander* b)
 		fprintf(f, "%s prefix-list %s deny %s\n",
 			(b->family==AF_INET) ? "ip" : "ipv6", bname,
 			(b->family==AF_INET) ? "0.0.0.0/0" : "::/0");
+		return 1;
 	};
 	return 0;
 };
@@ -931,6 +935,7 @@ bgpq3_print_bird_prefixlist(FILE* f, struct bgpq_expander* b)
 		fprintf(f,"\n];\n");
 	} else {
 		SX_DEBUG(debug_expander, "skip empty prefix-list in BIRD format\n");
+		return 1;
 	};
 	return 0;
 };
@@ -991,6 +996,7 @@ bgpq3_print_cisco_eacl(FILE* f, struct bgpq_expander* b)
 	} else {
 		fprintf(f,"! generated access-list %s is empty\n", bname);
 		fprintf(f,"ip access-list extended %s deny any any\n", bname);
+		return 1;
 	};
 	return 0;
 };
@@ -1006,6 +1012,7 @@ bgpq3_print_nokia_ipprefixlist(FILE* f, struct bgpq_expander* b)
 		sx_radix_tree_foreach(b->tree,bgpq3_print_nokia_ipfilter,f);
 	} else {
 		fprintf(f,"# generated ip-prefix-list %s is empty\n", bname);
+		return 1;
 	};
 	fprintf(f,"exit\n");
 	return 0;

--- a/bgpq_expander.c
+++ b/bgpq_expander.c
@@ -17,6 +17,11 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#if __OpenBSD__
+#include <sys/select.h>
+#endif
+
+
 #include "bgpq3.h"
 #include "sx_report.h"
 #include "sx_maxsockbuf.h"


### PR DESCRIPTION
Returning not 0 when an error occurs is useful when using bgpq3 in a script to generate a lot of filters