### PR TITLE
Further cleanup OpenBGPD prefix-sets

### DIFF
--- a/bgpq3_printer.c
+++ b/bgpq3_printer.c
@@ -691,17 +691,16 @@ bgpq3_print_openbgpd_prefix(struct sx_radix_node* n, void* ff)
 		f=stdout;
 	sx_prefix_snprintf(&n->prefix, prefix, sizeof(prefix));
 	if (!n->isAggregate) {
-		fprintf(f, "\n\t%s \\", prefix);
+		fprintf(f, "\n\t%s", prefix);
 	} else if (n->aggregateLow == n->aggregateHi) {
-		fprintf(f, "\n\t%s prefixlen = %u \\", prefix, n->aggregateHi);
+		fprintf(f, "\n\t%s prefixlen = %u", prefix, n->aggregateHi);
 	} else if (n->aggregateLow > n->prefix.masklen) {
-		fprintf(f, "\n\t%s prefixlen %u - %u \\",
+		fprintf(f, "\n\t%s prefixlen %u - %u",
 			prefix, n->aggregateLow, n->aggregateHi);
 	} else {
-		fprintf(f, "\n\t%s prefixlen %u - %u \\",
+		fprintf(f, "\n\t%s prefixlen %u - %u",
 			prefix, n->prefix.masklen, n->aggregateHi);
 	};
-	needscomma=1;
 checkSon:
 	if(n->son)
 		bgpq3_print_openbgpd_prefix(n->son, ff);
@@ -1010,7 +1009,7 @@ bgpq3_print_openbgpd_prefixlist(FILE* f, struct bgpq_expander* b)
 				fprintf(f, "%s=\"", b->name);
 			}
 		}
-		fprintf(f,"prefix { \\");
+		fprintf(f,"prefix { ");
 		sx_radix_tree_foreach(b->tree,bgpq3_print_openbgpd_prefix,f);
 		fprintf(f, "\n\t}");
 		if(b->name){
@@ -1037,9 +1036,9 @@ bgpq3_print_openbgpd_prefixset(FILE* f, struct bgpq_expander* b)
 				"instead of this list\n");
 	};
 	if (!sx_radix_tree_empty(b->tree) || !b->asnumber) {
-		fprintf(f,"prefix-set %s { \\", b->name);
+		fprintf(f,"prefix-set %s {", b->name);
 		sx_radix_tree_foreach(b->tree,bgpq3_print_openbgpd_prefix,f);
-		fprintf(f, "\n\t}\n");
+		fprintf(f, "\n}\n");
 	} else {
 		fprintf(f, "deny from AS %u\n", b->asnumber);
 	};

--- a/bgpq3_printer.c
+++ b/bgpq3_printer.c
@@ -1028,23 +1028,12 @@ int
 bgpq3_print_openbgpd_prefixset(FILE* f, struct bgpq_expander* b)
 {
 	bname=b->name ? b->name : "NN";
-	if (sx_radix_tree_empty(b->tree)) {
-		fprintf(f, "# generated prefix-set %s (AS %u) is empty\n", bname,
-			b->asnumber);
-		if (!b->asnumber)
-			fprintf(f, "# use -a <asn> to generate \"deny from ASN <asn>\" "
-				"instead of this list\n");
-	};
-	if (!sx_radix_tree_empty(b->tree) || !b->asnumber) {
-		fprintf(f,"prefix-set %s {", b->name);
+	fprintf(f,"prefix-set %s {", b->name);
+	if (!sx_radix_tree_empty(b->tree))
 		sx_radix_tree_foreach(b->tree,bgpq3_print_openbgpd_prefix,f);
-		fprintf(f, "\n}\n");
-	} else {
-		fprintf(f, "deny from AS %u\n", b->asnumber);
-	};
+	fprintf(f, "\n}\n");
 	return 0;
 };
-
 
 int
 bgpq3_print_cisco_prefixlist(FILE* f, struct bgpq_expander* b)


### PR DESCRIPTION
Remove all backslashes from the generated OpenBGPD config. They are not needed.
In -E mode it is perfectly fine to have empty prefix-sets. Using them will just work (the
filter rule will never match since the set is empty).