### PR TITLE
Update bgpq3.html

### DIFF
--- a/bgpq3.html
+++ b/bgpq3.html
@@ -1,5 +1,5 @@
-<p><!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.or
-g/TR/html4/loose.dtd"> <br />
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.or
+g/TR/html4/loose.dtd">  
 <html><head><style type='text/css'> 
 h1 { color: #3c78b5; border-bottom: 3px solid #3c78b5; font-size: 180%; } 
 h2 { color: #3c78b5; border-bottom: 2px solid #3c78b5; font-size: 140%; } 
@@ -9,136 +9,102 @@ code { font-size:12px; background-color:#f8f8ff; border:1px; }
 pre  { border: 1px dotted #3c78b5; background-color: #f8f8ff; margin: 1em 1em;} 
 body { width: 80%; margin: 0 3em; } 
 ul      { list-style: none; } 
-</style></head><body> </p>
+</style></head><body>
 
 <h2>NAME</h2>
-
-<p><code>bgpq3</code> - bgp filtering automation for Cisco and Juniper routers</p>
-
+<p><code>bgpq3</code> - bgp filtering automation tool</p>
 <h2>SYNOPSIS</h2>
-
-<p><code>
-    bgpq3 [-h host] [-S sources] [-EP] [-f asn | -G asn] [-2346AbDdJjpX] [-r len] [-R len] [-m max] [-W len] OBJECTS [...]
-</code></p>
-
+<p><code>bgpq3 [-h host[:port]] [-S sources] [-EPz] [-f asn | -F fmt | -G asn | -t] [-2346ABbDdJjNnpsUX] [-a asn] [-r len] [-R len] [-m max] [-W len] OBJECTS [...] EXCEPT OBJECTS</code></p>
 <h2>DESCRIPTION</h2>
-
-<p>The bgpq3 utility used to generate Cisco and Juniper prefix-lists,
-extended access-lists, policy-statement terms and as-path lists based on
-RADB data.</p>
-
+<p>The bgpq3 utility used to generate configuration (prefix-lists,
+extended access-lists, policy-statement terms and as-path lists)
+based on RADB data.</p>
 <p>The options are as follows:</p>
-
+<h4>-2</h4>
+<p>Allow routes registered for as23456 (transition-as) (default: false)</p>
 <h4>-3</h4>
-
 <p>Assume that your device is asn32-capable.</p>
-
 <h4>-4</h4>
-
 <p>Generate IPv4 prefix/access-lists (default).</p>
-
 <h4>-6</h4>
-
 <p>Generate IPv6 prefix/access-lists (IPv4 by default).</p>
-
 <h4>-A</h4>
-
 <p>Try to aggregate generated filters as much as possible (not all output formats
 supported).</p>
-
+<h4>-a asn</h4>
+<p>Specify ASN that shall be denied in case of empty prefix-list (OpenBGPD).</p>
+<h4>-B</h4>
+<p>Generate output in OpenBGPD format (default: Cisco).</p>
 <h4>-b</h4>
-
 <p>Generate output in BIRD format (default: Cisco).</p>
-
 <h4>-d</h4>
-
 <p>Enable some debugging output.</p>
-
 <h4>-D</h4>
-
 <p>Use asdot notation for Cisco as-path access-lists.</p>
-
 <h4>-E</h4>
-
 <p>Generate extended access-list (Cisco) or policy-statement term using
-route-filters (Juniper).</p>
-
+route-filters (Juniper), [ip|ipv6]-prefix-list (Nokia) or prefix-filter
+(OpenBGPD)</p>
 <h4>-f <code>AS number</code></h4>
-
 <p>Generate input as-path access-list for adjacent as <code>AS number</code>.</p>
-
+<h4>-F <code>fmt</code></h4>
+<p>Generate output in user-defined format.</p>
 <h4>-G <code>number</code></h4>
-
 <p>Generate output as-path access-list.</p>
-
-<h4>-h <code>host</code></h4>
-
+<h4>-h <code>host[:port]</code></h4>
 <p>Host running IRRD database (default: <code>whois.radb.net</code>).</p>
-
 <h4>-J</h4>
-
 <p>Generate config for Juniper (default: Cisco).</p>
-
 <h4>-j</h4>
-
 <p>Generate output in JSON format (default: Cisco).</p>
-
 <h4>-m <code>length</code></h4>
-
 <p>Maximum length of accepted prefixes (default: <code>32</code> for IPv4, <code>128</code> for IPv6).</p>
-
 <h4>-M <code>match</code></h4>
-
 <p>Extra match conditions for Juniper route-filters. See the examples section.</p>
-
+<h4>-n</h4>
+<p>Generate config for Nokia SR OS (former Alcatel-Lucent) MD-CLI (default: Cisco)</p>
+<h4>-N</h4>
+<p>Generate config for Nokia SR OS (former Alcatel-Lucent) classic CLI (default: Cisco)</p>
 <h4>-l <code>name</code></h4>
-
 <p><code>Name</code> of generated configuration stanza.</p>
-
+<h4>-L <code>limit</code></h4>
+<p>Limit recursion depth when expanding. This slows <code>bgpq3</code> a bit, but sometimes
+is a useful feature to prevent generated filters from growing too big.</p>
 <h4>-p</h4>
-
 <p>Enable use of private ASNs and ASNs used for documentation purpose only
 (default: disabled).</p>
-
 <h4>-P</h4>
-
 <p>Generate prefix-list (default behaviour, flag added for backward compatibility
 only).</p>
-
 <h4>-r <code>length</code></h4>
-
 <p>Allow more-specific routes with masklen starting with specified length.</p>
-
 <h4>-R <code>length</code></h4>
-
 <p>Allow more-specific routes up to specified masklen too.  (Please, note: objects
 with prefix-length greater than specified length will be always allowed.)</p>
-
+<h4>-s</h4>
+<p>Generate sequence numbers in IOS-style prefix-lists.</p>
 <h4>-S <code>sources</code></h4>
-
-<p>Use specified sources only (default: RADB,RIPE,APNIC).</p>
-
+<p>Use specified sources only (recommended: RADB,RIPE,APNIC).</p>
+<h4>-t</h4>
+<p>Generate as-sets for OpenBGPD (OpenBSD 6.4+), BIRD and JSON formats.</p>
 <h4>-T</h4>
-
 <p>Disable pipelining. (not recommended)</p>
-
+<h4>-U</h4>
+<p>Generate output in Huawei format (default: Cisco).</p>
 <h4>-W <code>length</code></h4>
-
 <p>Generate as-path strings of a given length maximum (0 for infinity).</p>
-
 <h4>-X</h4>
-
 <p>Generate config for Cisco IOS XR devices (plain IOS by default).</p>
-
+<h4>-z</h4>
+<p>Generate Juniper route-filter-list (JunOS 16.2+).</p>
 <h4><code>OBJECTS</code></h4>
-
 <p><code>OBJECTS</code> means networks (in prefix format), autonomous systems, as-sets and
 route-sets. If multiple objects are specified they will be merged.</p>
-
+<h4><code>EXCEPT OBJECTS</code></h4>
+<p>You can exclude autonomous sets, as-sets and route-sets found during
+expansion from future expansion.</p>
 <h2>EXAMPLES</h2>
-
 <p>Generating named Juniper prefix-filter for <code>AS20597</code>:</p>
-
 <pre><code> user@host:~&gt;bgpq3 -Jl eltel AS20597
  policy-options {
  replace:
@@ -159,10 +125,8 @@ route-sets. If multiple objects are specified they will be merged.</p>
   }
  }
 </code></pre>
-
 <p>For Cisco we can use aggregation (-A) flag to make this prefix-filter
 more compact:</p>
-
 <pre><code> user@host:~&gt;bgpq3 -Al eltel AS20597
  no ip prefix-list eltel
  ip prefix-list eltel permit 81.9.0.0/20
@@ -177,17 +141,13 @@ more compact:</p>
  ip prefix-list eltel permit 89.112.64.0/19
  ip prefix-list eltel permit 217.170.64.0/19 ge 20 le 20
 </code></pre>
-
 <p>and, as you see, prefixes <code>89.112.0.0/19</code> and <code>89.112.32.0/19</code> now aggregated 
 into single entry </p>
-
 <pre><code>ip prefix-list eltel permit 89.112.0.0/18 ge 19 le 19.
 </code></pre>
-
 <p>Well, for Juniper we can generate even more interesting policy-statement,
 using <code>-M &lt;extra match conditions&gt;</code>, <code>-r &lt;len&gt;</code>, <code>-R &lt;len&gt;</code> and hierarchical 
 names:</p>
-
 <pre><code> user@host:~&gt;bgpq3 -AJEl eltel/specifics -r 29 -R 32 -M "community blackhole" AS20597
 policy-options {
  policy-statement eltel {
@@ -209,22 +169,17 @@ replace:
  }
 }
 </code></pre>
-
 <p>generated policy-option term now allows more-specific routes in range
 /29 - /32 for eltel networks if they marked with community 'blackhole' 
 (defined elsewhere in configuration).</p>
-
 <p>Of course, <code>bgpq3</code> supports IPv6 (-6):</p>
-
 <pre><code> user@host:~&gt;bgpq3 -6l as-retn-6 AS-RETN6
  no ipv6 prefix-list as-retn-6
  ipv6 prefix-list as-retn-6 permit 2001:7fb:fe00::/48
  ipv6 prefix-list as-retn-6 permit 2001:7fb:fe01::/48
  [....]
 </code></pre>
-
 <p>and ASN32</p>
-
 <pre><code> user@host:~&gt;bgpq3 -J3f 112 AS-SPACENET
  policy-options {
  replace:
@@ -236,12 +191,9 @@ replace:
   }
  }
 </code></pre>
-
 <p>see <code>AS196611</code> in the end of the list ? That's <code>AS3.3</code> in 'asplain' notation.</p>
-
 <p>If your router does not support ASN32 (yet) you should not use switch -3, 
 and the result will be next:</p>
-
 <pre><code> user@host:~&gt;bgpq3 -f 112 AS-SPACENET
  no ip as-path access-list NN
  ip as-path access-list NN permit ^112( 112)*$
@@ -251,54 +203,57 @@ and the result will be next:</p>
  ip as-path access-list NN permit ^112( [0-9]+)* (25152|31529|34127|34906)$
  ip as-path access-list NN permit ^112( [0-9]+)* (35052|41720|43628|44450)$
 </code></pre>
-
 <p><code>AS196611</code> is no more in the list, however, <code>AS23456</code> (transition AS) would
 have been added to list if it were not present.</p>
-
+<h2>USER-DEFINED FORMAT</h2>
+<p>If you want to generate configuration not for routers, but for some
+other programs/systems, you may use user-defined formatting, like in
+example below:</p>
+<pre><code>user@host:~&gt;bgpq3 -F "ipfw add pass all from %n/%l to any\\n" as3254
+ipfw add pass all from 62.244.0.0/18 to any
+ipfw add pass all from 91.219.29.0/24 to any
+ipfw add pass all from 91.219.30.0/24 to any
+ipfw add pass all from 193.193.192.0/19 to any
+</code></pre>
+<p>Recognized format characters: '%n' - network, '%l' - mask length,
+'%N' - object name, '%m' - object mask and '%i' - inversed mask.
+Recognized escape characters: '\n' - new line, '\t' - tabulation.
+Please note that no new lines inserted automatically after each sentence,
+you have to add them into format string manually, elsewhere output will
+be in one line (sometimes it makes sense):</p>
+<pre><code>user@host:~&gt;bgpq3 -6F "%n/%l; " as-eltel
+2001:1b00::/32; 2620:4f:8000::/48; 2a04:bac0::/29; 2a05:3a80::/48;
+</code></pre>
 <h2>DIAGNOSTICS</h2>
-
 <p>When everything is OK, <code>bgpq3</code> generates result to standard output and
 exits with status == 0.  In case of errors they are printed to stderr and
 program exits with non-zero status.</p>
-
 <h2>NOTES ON ULTRA-LARGE PREFIX-LISTS</h2>
-
 <p>To improve <code>bgpq3</code> performance when expanding extra-large AS-SETs you
 shall tune OS settings to enlarge TCP send buffer.</p>
-
 <p>FreeBSD can be tuned in the following way:</p>
-
 <pre><code>sysctl -w net.inet.tcp.sendbuf_max=2097152
 </code></pre>
-
 <p>Linux can be tuned in the following way:</p>
-
 <pre><code>sysctl -w net.ipv4.tcp_window_scaling=1
 sysctl -w net.core.rmem_max=2097152
 sysctl -w net.core.wmem_max=2097152
 sysctl -w net.ipv4.tcp_rmem="4096 87380 2097152"
 sysctl -w net.ipv4.tcp_wmem="4096 65536 2097152"
 </code></pre>
-
 <p>Please note that generated prefix-lists may not fit your router's
 limitations. For example, JunOS supports only 85,325 prefixes in 
 each prefix-list <a href="http://www.juniper.net/techpubs/en_US/junos11.4/topics/reference/configuration-statement/prefix-list-edit-policy-options.html">4</a>. </p>
-
 <h2>SEE ALSO</h2>
-
 <ol>
 <li><a href="http://www.radb.net/">Routing Arbiter</a></li>
-<li><a href="http://www.ietf.org/internet-drafts/draft-michaelson-4byte-as-representation-05.txt">draft-michaelson-4byte-as-representation-05.txt</a>
- for information on 'asdot' and 'asplain' notations.</li>
+<li><a href="https://tools.ietf.org/html/draft-michaelson-4byte-as-representation-05">draft-michaelson-4byte-as-representation-05</a>
+     for information on 'asdot' and 'asplain' notations.</li>
 <li><a href="http://www.cisco.com/en/US/prod/collateral/iosswrel/ps6537/ps6554/ps6599/data_sheet_C78-521821.html">Cisco documentation</a>
- for information on Cisco implementation of ASN32.</li>
+     for information on Cisco implementation of ASN32.</li>
 <li><a href="http://www.juniper.net/techpubs/en_US/junos11.4/topics/reference/configuration-statement/prefix-list-edit-policy-options.html">JunOS prefix-lists limitation</a></li>
 </ol>
-
 <h2>AUTHOR</h2>
-
 <p>Alexandre Snarskii <a href="mailto:snar@snar.spb.ru">snar@snar.spb.ru</a></p>
-
 <h2>Program Homepage</h2>
-
 <p><a href="http://snar.spb.ru/prog/bgpq3/">http://snar.spb.ru/prog/bgpq3/</a></p>


### PR DESCRIPTION
Some portions were outdated. Notably, the default sources were said to be RADB,RIPE,ARIN while this is not true anymore.

Wouldn't it better to not ship generated files in git? People would have to run `autoreconf -i` themselves, but it would avoid having outdated files.